### PR TITLE
bar.update('') screws up counter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -198,8 +198,8 @@ StatusBar.prototype.update = function (chunk){
   this._secondsWithoutUpdate = 0;
   
   //Allow any object with a length property
-  var length = chunk.length || chunk;
-  this._current += length;
+  var length = chunk.length != null ? chunk.length : chunk;
+  this._current += Number(length);
   
   this._updateStats (length);
   


### PR DESCRIPTION
If chunk is an empty string, this code:

``` js
var length = chunk.length || chunk;
this._current += length;
```

... would result in `this._current += ''`, so this._current (and currentSize later) becomes string as well.

PS: I wonder what should happen if someone writes `bar.update(null)`...
