### PR TITLE
"speed" state becomes and remains "Infinite"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -220,7 +220,7 @@ StatusBar.prototype._updateStats = function (length) {
     } else {
       // Bytes per second
       var speed = (length * 1e9) / elapsed;
-      var lastSpeed = this._stats.speed || speed;
+      var lastSpeed = isFinite(this._stats.speed) && this._stats.speed ? this._stats.speed : speed;
 
       // Smooth the speed
       speed = (1 - this._speedSmooth) * speed + this._speedSmooth * lastSpeed;


### PR DESCRIPTION
![screenshot_1](https://cloud.githubusercontent.com/assets/2454284/9826447/12df7aac-58e3-11e5-810d-213f1f31eaf5.png)

When first chunk arrives `_start` is initialized with current date. In the same thread `_updateStats` is called:
![screenshot_2](https://cloud.githubusercontent.com/assets/2454284/9826522/b909a29a-58e3-11e5-9b32-5f39e0125a3d.png)

It is the cause of `Infinite` value for `avgSpeed` variable inside `_updateStats`, because current and saved dates are the same and `elapsed` evaluates to zero:
![screenshot_5](https://cloud.githubusercontent.com/assets/2454284/9826694/d7e1016c-58e4-11e5-8887-a36dd3d1f570.png)

Then `Infinite` rolls to `this._stats.speed`.

Apart from provided by this pull request patch please consider moving `_start` initialization to earliest possible point, so that `elapsed` will not evaluate to zero.

Thank you.
